### PR TITLE
52: [CI] Standardize CI builds to use validate job naming

### DIFF
--- a/.github/workflows/cert-ci.yml
+++ b/.github/workflows/cert-ci.yml
@@ -7,8 +7,7 @@ on:
       - 'cert.yaml'
 
 jobs:
-  validate-template:
-    name: Validate Certificate CloudFormation
+  validate:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dns-records-ci.yml
+++ b/.github/workflows/dns-records-ci.yml
@@ -7,8 +7,7 @@ on:
       - 'dns-records.yaml'
 
 jobs:
-  validate-template:
-    name: Validate DNS Records CloudFormation
+  validate:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dns-zone-ci.yml
+++ b/.github/workflows/dns-zone-ci.yml
@@ -7,8 +7,7 @@ on:
       - 'dns-zone.yaml'
 
 jobs:
-  validate-template:
-    name: Validate DNS Zone CloudFormation
+  validate:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   validate:
-    name: Validate Next.js Application
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
All CI builds should use the job name "validate" without a user friendly name. This allows a singular github action required status check "validate" which applies to all CI builds

closes #52