### PR TITLE
66: [github] Update auto approve workflow to use AUTO_APPROVE_PAT secret

### DIFF
--- a/.github/workflows/auto-approve-afisch710.yml
+++ b/.github/workflows/auto-approve-afisch710.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: hmarr/auto-approve-action@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.AUTO_APPROVE_PAT }}


### PR DESCRIPTION
Update the workflow to use the new auto approve PAT

closes #66