### PR TITLE
124: [netlify] Can't find bad CDN URL for CMS JS

### DIFF
--- a/web/public/admin/index.html
+++ b/web/public/admin/index.html
@@ -7,12 +7,12 @@
     <title>Content Manager | Alex Fischman</title>
 
     <!-- Netlify CMS default styles -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/netlify-cms@2.15.71/dist/netlify-cms.css" />
+    <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.css" />
 </head>
 
 <body>
     <!-- Load the CMS runtime -->
-    <script src="https://cdn.jsdelivr.net/npm/netlify-cms@2.15.71/dist/netlify-cms.js"></script>
+    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
     <script>
         CMS.init({
             backend: {


### PR DESCRIPTION
Use good CDN for CMS JS

closes #124