### PR TITLE
136: [infra] packages bucket should allow puts from github action role

### DIFF
--- a/infra-packages.yaml
+++ b/infra-packages.yaml
@@ -50,7 +50,7 @@ Resources:
           - Sid: AllowGitHubActionsUpload
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+              AWS: 'arn:aws:iam::561338195156:user/github-alexfischman.dev-dev-actions'
             Action:
               - s3:PutObject
               - s3:GetObject


### PR DESCRIPTION
Add correct role for put permission in infra package bucket

closes #136