### PR TITLE
146: [web] Cloudformation temaplate deploy failed due to bad CDN route using old stage name

### DIFF
--- a/web/cloudformation.yaml
+++ b/web/cloudformation.yaml
@@ -57,10 +57,6 @@ Resources:
               OriginProtocolPolicy: http-only
           - Id: OAuthApi
             DomainName: !ImportValue 'alexfischman-dev-oauth-ApiEndpoint'
-            OriginPath:
-              Fn::Sub:
-                - '/${Stage}'
-                - Stage: !ImportValue alexfischman-dev-oauth-ApiStageName
             CustomOriginConfig:
               HTTPPort: 80
               HTTPSPort: 443


### PR DESCRIPTION
Removing stage name that's not applicable anymore

closes #146