### PR TITLE
200: [oauth] Use same site cookie-backed token

### DIFF
--- a/services/oauth/src/index.js
+++ b/services/oauth/src/index.js
@@ -77,29 +77,13 @@ exports.handler = async (event) => {
 
     const token = tokenData.access_token;
 
-    // 3. Return HTML snippet to authenticate CMS and close window
-    const html = `<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"></head>
-<body>
-  <script>
-    // Send OAuth token back to CMS via postMessage
-    if (window.opener) {
-      window.opener.postMessage(
-        { type: 'OAUTH_SUCCESS', token: "${token}" },
-        '*' // allow any origin; CMS should verify message origin
-      );
-    }
-    window.close();
-  </script>
-  <noscript>Please close this window and return to the CMS.</noscript>
-</body>
-</html>`;
-
+    // 3. Set OAuth token in HttpOnly cookie and redirect to CMS
     return {
-      statusCode: 200,
-      headers: { 'Content-Type': 'text/html', 'Cache-Control': 'no-store' },
-      body: html
+      statusCode: 302,
+      headers: {
+        'Set-Cookie': `github_oauth_token=${token}; HttpOnly; Secure; SameSite=Lax; Path=/admin`,
+        'Location': '/admin/'
+      }
     };
   } catch (error) {
     console.error('OAuth proxy error:', error);

--- a/web/public/admin/index.html
+++ b/web/public/admin/index.html
@@ -10,29 +10,6 @@
 </head>
 
 <body>
-    <script>
-        window.addEventListener('message', (event) => {
-            const { type, token, error } = event.data || {};
-            function tryAuth() {
-                if (!window.CMS) {
-                    return setTimeout(tryAuth, 50);
-                }
-                if (type === 'OAUTH_SUCCESS') {
-                    // Use Netlify CMS OAuth callback
-                    if (window.CMS.oauthCallback) {
-                        window.CMS.oauthCallback(token);
-                        window.location.reload();
-                    }
-                } else if (type === 'OAUTH_ERROR') {
-                    // Use Netlify CMS OAuth error callback
-                    if (window.CMS.oauthError) {
-                        window.CMS.oauthError(error);
-                    }
-                }
-            }
-            tryAuth();
-        });
-    </script>
     <script src="https://unpkg.com/netlify-cms@^2/dist/netlify-cms.js"></script>
 </body>
 


### PR DESCRIPTION
Use a cookie backed token rather than client side access token management

closes #200