### PR TITLE
235: [meta] Create standardized header component for meta tags and link previews

### DIFF
--- a/web/src/components/common/Head.tsx
+++ b/web/src/components/common/Head.tsx
@@ -1,0 +1,38 @@
+import Head from 'next/head';
+import React from 'react';
+
+interface HeadProps {
+    title: string;
+    description: string;
+    ogImage?: string;
+    ogUrl?: string;
+    ogType?: string;
+}
+
+export default function CustomHead({
+    title,
+    description,
+    ogImage = '/og-image.png', // Default OG image
+    ogUrl = 'https://www.alexfischman.dev', // Default URL
+    ogType = 'website', // Default OG type
+}: HeadProps) {
+    return (
+        <Head>
+            {/* Primary Meta Tags */}
+            <title>{title}</title>
+            <meta name="description" content={description} />
+
+            {/* Open Graph */}
+            <meta property="og:type" content={ogType} />
+            <meta property="og:title" content={title} />
+            <meta property="og:description" content={description} />
+            <meta property="og:url" content={ogUrl} />
+            <meta property="og:image" content={`https://www.alexfischman.dev/${ogImage}`} />
+
+            {/* Twitter Card */}
+            <meta name="twitter:title" content={title} />
+            <meta name="twitter:description" content={description} />
+            <meta name="twitter:image" content={`https://www.alexfischman.dev/${ogImage}`} />
+        </Head>
+    );
+} 

--- a/web/src/pages/about.tsx
+++ b/web/src/pages/about.tsx
@@ -1,12 +1,12 @@
 "use client";
 import React from 'react';
-import Head from 'next/head';
 import { Box, Typography, Container, Link, Paper } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import EmailIcon from '@mui/icons-material/Email';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import aboutData from '@/data/about.json';
+import CustomHead from '@/components/common/Head';
 // Keep the import but don't use it for now
 // import GithubProfile from '@/components/github/GithubProfile';
 
@@ -15,47 +15,12 @@ export default function About() {
 
     return (
         <>
-            <Head>
-                {/* Primary Meta Tags */}
-                <title>{aboutData.title}</title>
-                <meta
-                    name="description"
-                    content={aboutData.description}
-                />
-
-                {/* Open Graph */}
-                <meta property="og:type" content="website" />
-                <meta
-                    property="og:title"
-                    content={aboutData.title}
-                />
-                <meta
-                    property="og:description"
-                    content={aboutData.description}
-                />
-                <meta
-                    property="og:url"
-                    content="https://www.alexfischman.dev/about"
-                />
-                <meta
-                    property="og:image"
-                    content={`https://www.alexfischman.dev/${aboutData.ogImage}`}
-                />
-
-                {/* Twitter Card */}
-                <meta
-                    name="twitter:title"
-                    content={aboutData.title}
-                />
-                <meta
-                    name="twitter:description"
-                    content={aboutData.description}
-                />
-                <meta
-                    name="twitter:image"
-                    content={`https://www.alexfischman.dev/${aboutData.ogImage}`}
-                />
-            </Head>
+            <CustomHead
+                title={aboutData.title}
+                description={aboutData.description}
+                ogImage={aboutData.ogImage}
+                ogUrl="https://www.alexfischman.dev/about"
+            />
             <Container maxWidth="lg" sx={{ py: 4 }}>
                 <Paper
                     elevation={3}

--- a/web/src/pages/blog/[slug].tsx
+++ b/web/src/pages/blog/[slug].tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import Head from 'next/head';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import { Container } from '@mui/material';
 import BlogPost from '../../components/blog/BlogPost';
 import { Post } from '../../types/blog';
 import postsData from '../../data/posts.json';
+import CustomHead from '@/components/common/Head';
 
 interface BlogPostPageProps {
   post: Post;
@@ -13,13 +13,12 @@ interface BlogPostPageProps {
 export default function BlogPostPage({ post }: BlogPostPageProps) {
   return (
     <>
-      <Head>
-        <title key="title">{`${post.title} | Alex Fischman`}</title>
-        <meta key="description" name="description" content={post.description} />
-        <meta key="og:title" property="og:title" content={`${post.title} | Alex Fischman`} />
-        <meta key="og:description" property="og:description" content={post.description} />
-        <meta key="og:image" property="og:image" content={post.ogImage || '/af_dark.png'} />
-      </Head>
+      <CustomHead
+        title={`${post.title} | Alex Fischman`}
+        description={post.description}
+        ogImage={post.ogImage || 'af_dark.png'}
+        ogUrl={`https://www.alexfischman.dev/blog/${post.slug}`}
+      />
       <Container>
         <BlogPost post={post} />
       </Container>

--- a/web/src/pages/blog/index.tsx
+++ b/web/src/pages/blog/index.tsx
@@ -1,51 +1,21 @@
 'use client';
 import React from 'react';
-import Head from 'next/head';
 import { Box, Typography } from '@mui/material';
 import { GetStaticProps } from 'next';
 import type { Post } from '../../types/blog';
 import postsData from '../../data/posts.json';
 import BlogPreview from '@/components/blog/BlogPreview';
+import CustomHead from '@/components/common/Head';
 
 export default function BlogIndex({ posts }: { posts: Post[] }) {
-
     return (
         <>
-            <Head>
-                {/* Primary Meta Tags */}
-                <title>Blog | Alex Fischman</title>
-                <meta
-                    name="description"
-                    content="Read the latest blog posts by Alex Fischman on software engineering, AI, technology, weather, and more."
-                />
-
-                {/* Open Graph */}
-                <meta property="og:type" content="website" />
-                <meta
-                    property="og:title"
-                    content="Blog | Alex Fischman"
-                />
-                <meta
-                    property="og:description"
-                    content="Read the latest blog posts by Alex Fischman on software engineering, AI, technology, weather, and more."
-                />
-                <meta property="og:url" content="https://www.alexfischman.dev/blog" />
-                <meta property="og:image" content="https://www.alexfischman.dev/af_dark.png" />
-
-                {/* Twitter Card */}
-                <meta name="twitter:card" content="summary_large_image" />
-                <meta name="twitter:site" content="@your_twitter_handle" />
-                <meta
-                    name="twitter:title"
-                    content="Blog | Alex Fischman"
-                />
-                <meta
-                    name="twitter:description"
-                    content="Read the latest blog posts by Alex Fischman on software engineering, AI, technology, weather, and more."
-                />
-                <meta property="twitter:image" content="https://www.alexfischman.dev/af_dark.png" />
-            </Head>
-
+            <CustomHead
+                title="Blog | Alex Fischman"
+                description="Read the latest blog posts by Alex Fischman on software engineering, AI, technology, weather, and more."
+                ogImage="af_dark.png"
+                ogUrl="https://www.alexfischman.dev/blog"
+            />
             <Box sx={{ minHeight: '100%', display: 'flex', flexDirection: 'column' }}>
                 <>
                     <Typography variant="h3" gutterBottom>

--- a/web/src/pages/experience/[slug].tsx
+++ b/web/src/pages/experience/[slug].tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import Head from 'next/head';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import { Container } from '@mui/material';
 import ExperiencePage from '@/components/experience/ExperiencePage';
 import type { Experience } from '../../types/experience';
 import experiencesData from '../../data/experience.json';
+import CustomHead from '@/components/common/Head';
 
 interface ExperienceSlugPageProps {
   experience: Experience;
@@ -13,13 +13,12 @@ interface ExperienceSlugPageProps {
 export default function ExperienceSlugPage({ experience }: ExperienceSlugPageProps) {
   return (
     <>
-      <Head>
-        <title key="title">{`${experience.title} | Alex Fischman`}</title>
-        <meta key="description" name="description" content={experience.description} />
-        <meta key="og:title" property="og:title" content={`${experience.title} | Alex Fischman`} />
-        <meta key="og:description" property="og:description" content={experience.description} />
-        <meta key="og:image" property="og:image" content={experience.ogImage || '/af_dark.png'} />
-      </Head>
+      <CustomHead
+        title={`${experience.title} | Alex Fischman`}
+        description={experience.description}
+        ogImage={experience.ogImage || 'af_dark.png'}
+        ogUrl={`https://www.alexfischman.dev/experience/${experience.slug}`}
+      />
       <Container>
         <ExperiencePage experience={experience} />
       </Container>

--- a/web/src/pages/experience/index.tsx
+++ b/web/src/pages/experience/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo } from 'react';
-import Head from 'next/head';
 import { Box, Typography, Chip, IconButton, Collapse } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import FilterListIcon from '@mui/icons-material/FilterList';
@@ -7,6 +6,7 @@ import { GetStaticProps } from 'next';
 import type { Experience } from '../../types/experience';
 import experiencesData from '../../data/experience.json';
 import ExperienceCard from '../../components/experience/ExperienceCard';
+import CustomHead from '@/components/common/Head';
 
 export default function ExperiencePage({
     experiences,
@@ -77,37 +77,12 @@ export default function ExperiencePage({
 
     return (
         <>
-            <Head>
-                <title>Experience | Alex Fischman – Senior Software Engineer & Founder</title>
-                <meta
-                    name="description"
-                    content="Explore projects and professional experiences by Alex Fischman."
-                />
-                {/* Open Graph */}
-                <meta property="og:type" content="website" />
-                <meta
-                    property="og:title"
-                    content="Experience | Alex Fischman – Senior Software Engineer & Founder"
-                />
-                <meta
-                    property="og:description"
-                    content="Explore projects and professional experiences by Alex Fischman."
-                />
-                <meta property="og:url" content="https://www.alexfischman.dev/experience" />
-                <meta property="og:image" content="https://www.alexfischman.dev/af_dark.png" />
-                {/* Twitter Card */}
-                <meta name="twitter:card" content="summary_large_image" />
-                <meta name="twitter:site" content="@your_twitter_handle" />
-                <meta
-                    name="twitter:title"
-                    content="Experience | Alex Fischman – Senior Software Engineer & Founder"
-                />
-                <meta
-                    name="twitter:description"
-                    content="Explore projects and professional experiences by Alex Fischman."
-                />
-                <meta property="twitter:image" content="https://www.alexfischman.dev/af_dark.png" />
-            </Head>
+            <CustomHead
+                title="Experience | Alex Fischman – Senior Software Engineer & Founder"
+                description="Explore projects and professional experiences by Alex Fischman."
+                ogImage="af_dark.png"
+                ogUrl="https://www.alexfischman.dev/experience"
+            />
             <Box sx={{ width: '100%', p: 4, pb: 8 }}>
                 {/* Header with title and filter toggle icon */}
                 <Box

--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 import React, { useState, useEffect, useCallback } from 'react';
-import Head from 'next/head';
 import { Box, Typography, Container, Button, Fade, Zoom, TypographyProps, SxProps, Theme, alpha } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import NextLink from 'next/link';
@@ -12,6 +11,7 @@ import experiencesData from '@/data/experience.json';
 import ExperienceCard from '@/components/experience/ExperienceCard';
 import postsData from '@/data/posts.json';
 import GithubProfile from '@/components/github/GithubProfile';
+import CustomHead from '@/components/common/Head';
 
 // Track if intro has played in this SPA session
 let introPlayedInApp = false;
@@ -127,24 +127,12 @@ export default function Home({
 
     return (
         <>
-            <Head>
-                {/* Primary meta tags */}
-                <title>Alex Fischman | Senior Software Engineer & Founder</title>
-                <meta name="description" content="Blog, experience, and about me." />
-
-                {/* Open Graph / Facebook */}
-                <meta property="og:type" content="website" />
-                <meta property="og:title" content="Alex Fischman | Senior Software Engineer & Founder" />
-                <meta property="og:description" content="Blog, experience, and about me." />
-                <meta property="og:url" content="https://www.alexfischman.dev/" />
-                <meta property="og:image" content="https://www.alexfischman.dev/af_dark.png" />
-
-                {/* Twitter */}
-                <meta name="twitter:title" content="Alex Fischman | Senior Software Engineer & Founder" />
-                <meta name="twitter:description" content="Blog, experience, and about me." />
-                <meta name="twitter:image" content="https://www.alexfischman.dev/af_dark.png" />
-            </Head>
-
+            <CustomHead
+                title="Alex Fischman | Senior Software Engineer & Founder"
+                description="Blog, experience, and about me."
+                ogImage="af_dark.png"
+                ogUrl="https://www.alexfischman.dev/"
+            />
             <Container maxWidth="lg" sx={{ py: { xs: 2, md: 4 } }}>
                 {/* Global CSS for animations */}
                 <style>{`


### PR DESCRIPTION
Create a standardized header component for all pages to adopt for meta tags and link previews

closes #235