### PR TITLE
330: [blog] Update markdown to highlight links with accent color

### DIFF
--- a/web/src/components/blog/BlogPost.tsx
+++ b/web/src/components/blog/BlogPost.tsx
@@ -91,7 +91,16 @@ export default function BlogPost({ post }: BlogPostProps) {
                             />
                         ),
                         a: ({ href, children }) => (
-                            <MuiLink href={href} target="_blank" rel="noopener noreferrer" underline="hover">
+                            <MuiLink 
+                                href={href} 
+                                target="_blank" 
+                                rel="noopener noreferrer" 
+                                underline="hover"
+                                sx={{ 
+                                    color: 'primary.main',
+                                    fontWeight: 500
+                                }}
+                            >
                                 {children}
                             </MuiLink>
                         ),

--- a/web/src/theme.tsx
+++ b/web/src/theme.tsx
@@ -9,7 +9,7 @@ const theme = createTheme({
             'secondary': '#bbb',
         },
         primary: {
-            main: '#fff',
+            main: '#2196F3', // Light blue accent color matching standard hyperlinks
         },
         background: {
             paper: 'rgba(0,0,0,0.25)',


### PR DESCRIPTION
Add standard light blue accent colors to use for link display in blog markdown

closes #330