### PR TITLE
334: [blog] Use distinct accent color for links instead of primary.main

### DIFF
--- a/web/src/components/blog/BlogPost.tsx
+++ b/web/src/components/blog/BlogPost.tsx
@@ -97,7 +97,7 @@ export default function BlogPost({ post }: BlogPostProps) {
                                 rel="noopener noreferrer" 
                                 underline="hover"
                                 sx={{ 
-                                    color: 'primary.main',
+                                    color: 'secondary.main',
                                     fontWeight: 500
                                 }}
                             >

--- a/web/src/theme.tsx
+++ b/web/src/theme.tsx
@@ -9,13 +9,13 @@ const theme = createTheme({
             'secondary': '#bbb',
         },
         primary: {
-            main: '#2196F3', // Light blue accent color matching standard hyperlinks
+            main: '#fff',
         },
         background: {
             paper: 'rgba(0,0,0,0.25)',
         },
         secondary: {
-            main: '#555',
+            main: '#2196F3', // Light blue accent color for links
         },
     },
     components: {


### PR DESCRIPTION
Use new secondary.main theme color for links instead of primary.main

closes #334