### PR TITLE
352: [404] Incorrect S3 path used for 404 page

### DIFF
--- a/web/cloudformation.yaml
+++ b/web/cloudformation.yaml
@@ -24,7 +24,7 @@ Resources:
             MaxAge: 3000
       WebsiteConfiguration:
         IndexDocument: index.html
-        ErrorDocument: 404.html  # serve the proper 404 page for errors
+        ErrorDocument: 404/index.html  # serve the proper 404 page for errors
 
   WebsiteBucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
fix: update S3 error document path to point to 404 directory (#351)

closes #352