### PR TITLE
354: [blog] Add tag clamping and improve tag layout

### DIFF
--- a/web/src/components/blog/BlogCard.tsx
+++ b/web/src/components/blog/BlogCard.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import Link from "next/link";
-import { Card, CardActionArea, CardContent, Typography, Box, Button, Chip } from "@mui/material";
+import { Card, CardActionArea, CardContent, Typography, Box, Button } from "@mui/material";
 import { Post } from "../../types/blog";
+import TagClamp from "../common/TagClamp";
 
 interface BlogCardProps {
   post: Post;
@@ -32,10 +33,8 @@ export default function BlogCard({ post }: BlogCardProps) {
           <Typography variant="h6" gutterBottom sx={{ fontWeight: 700, color: 'text.primary', mb: 2 }}>
             {post.description}
           </Typography>
-          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
-            {post.tags.map((tag) => (
-              <Chip key={tag} label={tag} size="small" sx={{ borderRadius: '8px' }} />
-            ))}
+          <Box sx={{ mb: 2 }}>
+            <TagClamp tags={post.tags} maxLines={2} containerWidth={400} />
           </Box>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <Button variant="outlined" sx={{ textTransform: "none", color: "primary.main" }}>

--- a/web/src/components/blog/BlogPost.tsx
+++ b/web/src/components/blog/BlogPost.tsx
@@ -49,50 +49,53 @@ export default function BlogPost({ post }: BlogPostProps) {
                     {post.description}
                 </Typography>
                 {/* Author Section */}
-                <Box sx={{ display: 'flex', alignItems: 'center', mt: 2, mb: 4 }}>
-                    {/* Author headshot now links to the About page */}
-                    <Box
-                        component={NextLink}
-                        href="/about/"
-                        sx={{ display: 'inline-block', mr: 2 }}
-                    >
+                <Box sx={{ mt: 2, mb: 4 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                        {/* Author headshot now links to the About page */}
                         <Box
-                            component="img"
-                            src="/headshot.JPG"
-                            alt="Author headshot"
-                            sx={{
-                                width: 56,
-                                height: 56,
-                                borderRadius: '50%',
-                                border: '2px solid',
-                                borderColor: 'divider',
-                                cursor: 'pointer',
-                            }}
-                        />
-                    </Box>
-                    <Box>
-                        {/* Author name now links to the About page */}
-                        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                            <MuiLink
-                                component={NextLink}
-                                href="/about/"
-                                underline="hover"
+                            component={NextLink}
+                            href="/about/"
+                            sx={{ display: 'inline-block', mr: 2 }}
+                        >
+                            <Box
+                                component="img"
+                                src="/headshot.JPG"
+                                alt="Author headshot"
                                 sx={{
-                                    color: 'inherit',
-                                    textDecoration: 'none',
+                                    width: 56,
+                                    height: 56,
+                                    borderRadius: '50%',
+                                    border: '2px solid',
+                                    borderColor: 'divider',
+                                    cursor: 'pointer',
                                 }}
-                            >
-                                Alex Fischman
-                            </MuiLink>
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary">
-                            {`published ${formatPublishTime(post.date)}`}
-                        </Typography>
-                        <Box sx={{ mt: 1, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                            {post.tags.map((tag) => (
-                                <Chip key={tag} label={tag} size="small" sx={{ borderRadius: '8px' }} />
-                            ))}
+                            />
                         </Box>
+                        <Box>
+                            {/* Author name now links to the About page */}
+                            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                                <MuiLink
+                                    component={NextLink}
+                                    href="/about/"
+                                    underline="hover"
+                                    sx={{
+                                        color: 'inherit',
+                                        textDecoration: 'none',
+                                    }}
+                                >
+                                    Alex Fischman
+                                </MuiLink>
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary">
+                                {`published ${formatPublishTime(post.date)}`}
+                            </Typography>
+                        </Box>
+                    </Box>
+                    {/* Tags shown as separate row for all screen sizes */}
+                    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                        {post.tags.map((tag) => (
+                            <Chip key={tag} label={tag} size="small" sx={{ borderRadius: '8px' }} />
+                        ))}
                     </Box>
                 </Box>
                 <Divider sx={{ my: 4 }} />


### PR DESCRIPTION
refactor: enhance BlogCard and BlogPost components for improved tag display and author section layout

- Replaced individual tag Chips with a TagClamp component in BlogCard for better visual management of tags.
- Adjusted the author section in BlogPost to streamline layout and ensure tags are displayed in a separate row for all screen sizes.

closes #354