### PR TITLE
369: [footer] Reorder the footer icons so that Smarter Weather appears after Pourtle

### DIFF
--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -93,31 +93,6 @@ export default function Footer() {
                         <CodeIcon />
                     </IconButton>
                 </Tooltip>
-                <Tooltip title="Visit Smarter Weather">
-                    <IconButton
-                        href="https://smarterweather.com"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="Smarter Weather"
-                        sx={{
-                            color: theme.palette.text.primary,
-                            '&:hover': {
-                                color: theme.palette.primary.main,
-                            },
-                            '& img': {
-                                width: 24,
-                                height: 24,
-                            },
-                        }}
-                    >
-                        <Image 
-                            src="/smarterweather_light.svg" 
-                            alt="Smarter Weather" 
-                            width={24}
-                            height={24}
-                        />
-                    </IconButton>
-                </Tooltip>
                 <Tooltip title="Visit Pourtle">
                     <IconButton
                         href="https://pourtle.com"
@@ -138,6 +113,31 @@ export default function Footer() {
                         <Image 
                             src="/pourtle_logo.svg" 
                             alt="Pourtle" 
+                            width={24}
+                            height={24}
+                        />
+                    </IconButton>
+                </Tooltip>
+                <Tooltip title="Visit Smarter Weather">
+                    <IconButton
+                        href="https://smarterweather.com"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Smarter Weather"
+                        sx={{
+                            color: theme.palette.text.primary,
+                            '&:hover': {
+                                color: theme.palette.primary.main,
+                            },
+                            '& img': {
+                                width: 24,
+                                height: 24,
+                            },
+                        }}
+                    >
+                        <Image 
+                            src="/smarterweather_light.svg" 
+                            alt="Smarter Weather" 
                             width={24}
                             height={24}
                         />


### PR DESCRIPTION
Reorder footer icons: Pourtle before Smarter Weather

- Moved Pourtle icon to appear before Smarter Weather icon in footer
- Addresses issue #369

closes #369