### PR TITLE
371: [agent] Update gpa.sh so that the PR is created with the 'agent' label

### DIFF
--- a/.github/scripts/shell/functions/gpa.sh
+++ b/.github/scripts/shell/functions/gpa.sh
@@ -48,6 +48,7 @@ gpa() {
     --body "$pr_body" \
     --base development \
     --head "$current_branch" \
+    --label "agent" \
   )
 
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
Add 'agent' label to gpa.sh PR creation

- Modified gpa.sh to include --label "agent" flag
- All PRs created via gpa command will now have the 'agent' label
- Addresses issue #371

closes #371