### PR TITLE
381: [claude] Create a claude.md at repo root

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gcd)",
+      "Bash(gci:*)",
+      "Bash(git status:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(gpa)",
+      "Bash(gh issue view:*)",
+      "Bash(find:*)",
+      "Bash(touch:*)",
+      "Bash(cp:*)",
+      "Bash(ls:*)"
+    ],
+    "deny": []
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# SmarterWeather Development Guide
+
+## Agent Development Workflow
+
+For detailed instructions on the developer workflow for agents in this repository, please refer to [AGENT.md](./AGENT.md).
+
+### Quick Reference
+
+**Required workflow for all agents:**
+1. Review issue: `gh issue view <issue_number>`
+2. Create topic branch: `gci <issue_number>`
+3. Make code changes
+4. Stage changes: `git add <files>`
+5. Commit changes: `git commit -m "<message>"`
+6. Create PR: `gpa` (default) or `gp` (if explicitly permitted)
+7. Provide PR URL to @afisch710
+
+**Important Notes:**
+- All branches must use the `gci` command for issue-specific topic branches
+- Default to `gpa` for PR creation unless explicitly told to use `gp`
+- Target the `development` branch for all pull requests
+- Follow the complete workflow in AGENT.md unless explicitly instructed otherwise
+
+## Repository Information
+
+- **Main Branch**: `development`
+- **GitHub CLI**: Available for issue management
+- **Custom Scripts**: Located in `.github/scripts/shell/`


### PR DESCRIPTION
Add claude.md file to repo root

- Create claude.md at repository root as requested in issue #381
- Contains agent development workflow and repository information

closes #381