### PR TITLE
402: [analytics] Add Google Analytics tracking to website

### DIFF
--- a/.github/workflows/web-cd.yml
+++ b/.github/workflows/web-cd.yml
@@ -33,6 +33,8 @@ jobs:
     - name: Build Next.js Application
       run: yarn build
       working-directory: ./web
+      env:
+        NEXT_PUBLIC_GA_ID: ${{ secrets.NEXT_PUBLIC_GA_ID }}
 
     - name: Run Post-Build Script
       run: |

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,3 @@
 # GitHub Personal Access Token (public access only)
 GITHUB_PUBLIC_TOKEN=
+NEXT_PUBLIC_GA_ID= # Google Analytics Tag

--- a/web/README.md
+++ b/web/README.md
@@ -1,5 +1,16 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Environment Variables
+
+Create a `.env.local` file in the root directory and add the following:
+
+```bash
+# Google Analytics Configuration (optional)
+# Get your measurement ID from Google Analytics 4
+# Format: G-XXXXXXXXXX
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+```
+
 ## Getting Started
 
 First, run the development server:

--- a/web/README.md
+++ b/web/README.md
@@ -2,14 +2,25 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Environment Variables
 
-Create a `.env.local` file in the root directory and add the following:
+### Local Development
+Copy `.env.example` to `.env` and add your values:
 
 ```bash
+# Copy the template
+cp .env.example .env
+
+# Edit .env with your actual values
+# GitHub Personal Access Token (public access only)
+GITHUB_PUBLIC_TOKEN=your_github_token_here
 # Google Analytics Configuration (optional)
-# Get your measurement ID from Google Analytics 4
-# Format: G-XXXXXXXXXX
 NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 ```
+
+### Production Deployment
+Production deployments use GitHub repository secrets:
+- Secret name: `NEXT_PUBLIC_GA_ID`
+- Automatically injected during CI/CD build
+- No local environment file needed for production
 
 ## Getting Started
 

--- a/web/src/components/common/GoogleAnalytics.tsx
+++ b/web/src/components/common/GoogleAnalytics.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import Script from 'next/script';
+
+// Get GA measurement ID from environment variables
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+export default function GoogleAnalytics() {
+  const router = useRouter();
+
+  // Track page views on route changes
+  React.useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      if (typeof window !== 'undefined' && window.gtag) {
+        window.gtag('config', GA_MEASUREMENT_ID, {
+          page_path: url,
+        });
+      }
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
+  // Don't load analytics if no measurement ID is provided
+  if (!GA_MEASUREMENT_ID || GA_MEASUREMENT_ID === 'G-XXXXXXXXXX') {
+    return null;
+  }
+
+  return (
+    <>
+      {/* Google Analytics Script */}
+      <Script
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+      />
+      <Script
+        id="google-analytics"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+        }}
+      />
+    </>
+  );
+}
+
+// TypeScript declaration for gtag
+declare global {
+  interface Window {
+    gtag: (...args: any[]) => void;
+  }
+} 

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -10,6 +10,7 @@ import { VisibilityProvider } from "@/context/VisibilityProvider";
 import theme from "../theme";
 import type { AppProps } from "next/app";
 import { roboto } from "@/lib/fonts";
+import GoogleAnalytics from "@/components/common/GoogleAnalytics";
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
@@ -32,6 +33,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <link rel="icon" href="/af.ico" />
         <link rel="apple-touch-icon" href="/af_large.png" />
       </Head>
+      <GoogleAnalytics />
       <ThemeProvider theme={theme}>
         <VisibilityProvider>
           <PageLayout className={roboto.variable}>


### PR DESCRIPTION
feat: add Google Analytics 4 tracking

- Create GoogleAnalytics component with GA4 support
- Add environment variable support (NEXT_PUBLIC_GA_ID)
- Track page views and SPA route changes
- Use Next.js Script component for optimal loading
- Add TypeScript declarations for gtag
- Update README with environment variable documentation
- Privacy-friendly implementation (only loads with valid GA ID)

Addresses #402

closes #402