### PR TITLE
404: [privacy] Replace cookie banner with elegant privacy modal and footer link

### DIFF
--- a/web/src/components/common/PrivacyModal.tsx
+++ b/web/src/components/common/PrivacyModal.tsx
@@ -1,0 +1,224 @@
+import React, { useState, useEffect } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography, Box, Drawer, useTheme, useMediaQuery, IconButton } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+export default function PrivacyModal() {
+  const [open, setOpen] = useState(false);
+  const [analyticsEnabled, setAnalyticsEnabled] = useState<boolean | null>(null);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  useEffect(() => {
+    // Check current analytics preference
+    const consent = localStorage.getItem('cookie-consent');
+    // Default to enabled if no explicit choice has been made
+    setAnalyticsEnabled(consent === 'declined' ? false : true);
+
+    // Listen for privacy modal open events
+    const handleOpenModal = () => setOpen(true);
+    window.addEventListener('openPrivacyModal', handleOpenModal);
+
+    return () => {
+      window.removeEventListener('openPrivacyModal', handleOpenModal);
+    };
+  }, []);
+
+  const handleAccept = () => {
+    localStorage.setItem('cookie-consent', 'accepted');
+    setAnalyticsEnabled(true);
+    setOpen(false);
+  };
+
+  const handleDecline = () => {
+    localStorage.setItem('cookie-consent', 'declined');
+    setAnalyticsEnabled(false);
+    setOpen(false);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const privacyContent = (
+    <>
+              <Typography variant="body1" sx={{ mb: 2, lineHeight: 1.6 }}>
+          This website uses Google Analytics to understand how visitors interact with my site. 
+          This helps me improve your experience.
+        </Typography>
+      
+              <Typography variant="body2" sx={{ mb: 2, color: 'rgba(255, 255, 255, 0.7)' }}>
+          <strong>What I collect:</strong>
+          <br />• Page views and navigation patterns
+          <br />• Device and browser information
+          <br />• General location (country/city level)
+        </Typography>
+        
+        <Typography variant="body2" sx={{ mb: 2, color: 'rgba(255, 255, 255, 0.7)' }}>
+          <strong>What I don't collect:</strong>
+          <br />• Personal information (name, email, etc.)
+          <br />• Precise location data
+          <br />• Any data that identifies you personally
+        </Typography>
+
+      {analyticsEnabled !== null && (
+        <Box sx={{ 
+          mt: 2, 
+          p: 2, 
+          backgroundColor: 'rgba(255, 255, 255, 0.05)',
+          borderRadius: 1,
+          border: '1px solid rgba(255, 255, 255, 0.1)'
+        }}>
+          <Typography variant="body2" sx={{ color: 'rgba(255, 255, 255, 0.9)' }}>
+            <strong>Current Setting:</strong> Analytics {analyticsEnabled ? 'Enabled' : 'Disabled'}
+          </Typography>
+        </Box>
+      )}
+    </>
+  );
+
+  const actionButtons = (
+    <Box sx={{ 
+      display: 'flex', 
+      gap: 2,
+      flexDirection: isMobile ? 'column' : 'row',
+      width: isMobile ? '100%' : 'auto'
+    }}>
+      <Button 
+        onClick={handleDecline}
+        sx={{ 
+          color: 'rgba(255, 255, 255, 0.7)',
+          border: '1px solid rgba(255, 255, 255, 0.2)',
+          flex: isMobile ? 1 : 'none',
+          '&:hover': {
+            backgroundColor: 'rgba(255, 255, 255, 0.05)',
+            borderColor: 'rgba(255, 255, 255, 0.3)',
+          }
+        }}
+      >
+        Disable Analytics
+      </Button>
+      <Button 
+        onClick={handleAccept}
+        variant="contained"
+        sx={{ 
+          backgroundColor: 'rgba(255, 255, 255, 0.9)',
+          color: '#000',
+          flex: isMobile ? 1 : 'none',
+          '&:hover': {
+            backgroundColor: 'white',
+          }
+        }}
+      >
+        Enable Analytics
+      </Button>
+    </Box>
+  );
+
+  // Mobile: Bottom Drawer
+  if (isMobile) {
+    return (
+      <Drawer
+        anchor="bottom"
+        open={open}
+        onClose={handleClose}
+        PaperProps={{
+          sx: {
+            backgroundColor: 'rgba(20, 20, 20, 0.98)',
+            backdropFilter: 'blur(20px)',
+            borderTopLeftRadius: 16,
+            borderTopRightRadius: 16,
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+            borderBottom: 'none',
+            maxHeight: '80vh',
+            color: 'rgba(255, 255, 255, 0.9)'
+          }
+        }}
+        ModalProps={{
+          keepMounted: false,
+        }}
+      >
+        <Box sx={{ p: 3, pb: 4 }}>
+          {/* Header with close button */}
+          <Box sx={{ 
+            display: 'flex', 
+            justifyContent: 'space-between', 
+            alignItems: 'center',
+            mb: 2
+          }}>
+            <Typography variant="h6" sx={{ 
+              color: 'white', 
+              fontSize: '1.25rem',
+              fontWeight: 500
+            }}>
+              Privacy & Analytics
+            </Typography>
+            <IconButton 
+              onClick={handleClose}
+              sx={{ 
+                color: 'rgba(255, 255, 255, 0.7)',
+                '&:hover': {
+                  backgroundColor: 'rgba(255, 255, 255, 0.1)'
+                }
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Box>
+
+          {/* Drag indicator */}
+          <Box sx={{
+            width: 40,
+            height: 4,
+            backgroundColor: 'rgba(255, 255, 255, 0.3)',
+            borderRadius: 2,
+            mx: 'auto',
+            mb: 3
+          }} />
+
+          {/* Content */}
+          {privacyContent}
+          
+          {/* Actions */}
+          <Box sx={{ mt: 3 }}>
+            {actionButtons}
+          </Box>
+        </Box>
+      </Drawer>
+    );
+  }
+
+  // Desktop: Modal Dialog
+  return (
+    <Dialog 
+      open={open} 
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: {
+          backgroundColor: 'rgba(30, 30, 30, 0.95)',
+          backdropFilter: 'blur(10px)',
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          borderRadius: 2,
+        }
+      }}
+    >
+      <DialogTitle sx={{ 
+        color: 'white', 
+        fontSize: '1.25rem',
+        fontWeight: 500,
+        pb: 1
+      }}>
+        Privacy & Analytics
+      </DialogTitle>
+      
+      <DialogContent sx={{ color: 'rgba(255, 255, 255, 0.9)' }}>
+        {privacyContent}
+      </DialogContent>
+      
+      <DialogActions sx={{ p: 3, pt: 1 }}>
+        {actionButtons}
+      </DialogActions>
+    </Dialog>
+  );
+} 

--- a/web/src/components/common/PrivacyModal.tsx
+++ b/web/src/components/common/PrivacyModal.tsx
@@ -54,7 +54,7 @@ export default function PrivacyModal() {
         </Typography>
         
         <Typography variant="body2" sx={{ mb: 2, color: 'rgba(255, 255, 255, 0.7)' }}>
-          <strong>What I don't collect:</strong>
+          <strong>What I don&apos;t collect:</strong>
           <br />• Personal information (name, email, etc.)
           <br />• Precise location data
           <br />• Any data that identifies you personally

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -27,9 +27,9 @@ export default function Footer() {
             <Box sx={{ 
                 display: "flex", 
                 gap: 1,
-                order: { xs: 1, sm: 2 },
-                justifyContent: "center",
-                width: { xs: "100%", sm: "auto" }
+                order: { xs: 1, sm: 3 },
+                justifyContent: { xs: "center", sm: "flex-end" },
+                width: { xs: "100%", sm: "33%" }
             }}>
                 <Tooltip title="View Alex's GitHub">
                     <IconButton
@@ -145,18 +145,83 @@ export default function Footer() {
                 </Tooltip>
             </Box>
             
+            {/* Left Privacy Link - Desktop Only */}
+            <Box sx={{
+                display: { xs: 'none', sm: 'flex' },
+                justifyContent: 'flex-start',
+                alignItems: 'center',
+                width: '33%',
+                order: 1
+            }}>
+                <Typography 
+                    variant="body2" 
+                    component="button"
+                    onClick={() => {
+                        const event = new CustomEvent('openPrivacyModal');
+                        window.dispatchEvent(event);
+                    }}
+                    sx={{
+                        fontSize: '0.875rem',
+                        color: 'text.secondary',
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        textDecoration: 'underline',
+                        padding: 0,
+                        '&:hover': {
+                            color: 'text.primary',
+                        },
+                    }}
+                >
+                    Privacy
+                </Typography>
+            </Box>
+            
             <Typography 
                 variant="body2" 
                 color="text.secondary"
                 sx={{
                     fontSize: { xs: '0.7rem', sm: '0.875rem' },
-                    order: { xs: 2, sm: 1 },
-                    textAlign: { xs: "center", sm: "left" },
-                    width: { xs: "100%", sm: "auto" }
+                    order: { xs: 2, sm: 2 },
+                    textAlign: "center",
+                    width: { xs: "100%", sm: "33%" },
+                    display: { xs: "block", sm: "block" }
                 }}
             >
                 © {currentYear} Alex Fischman. All rights reserved.
             </Typography>
+            
+            {/* Mobile Privacy Link - Below Copyright */}
+            <Box sx={{
+                display: { xs: 'flex', sm: 'none' },
+                justifyContent: 'center',
+                width: '100%',
+                order: 3,
+                mt: 0.5
+            }}>
+                <Typography 
+                    variant="body2" 
+                    component="button"
+                    onClick={() => {
+                        const event = new CustomEvent('openPrivacyModal');
+                        window.dispatchEvent(event);
+                    }}
+                    sx={{
+                        fontSize: '0.7rem',
+                        color: 'text.secondary',
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        textDecoration: 'underline',
+                        padding: 0,
+                        '&:hover': {
+                            color: 'text.primary',
+                        },
+                    }}
+                >
+                    Privacy
+                </Typography>
+            </Box>
         </Box>
     );
 } 

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,51 @@
+// Google Analytics event tracking utilities
+
+declare global {
+  interface Window {
+    gtag: (...args: any[]) => void;
+  }
+}
+
+export const trackEvent = (
+  action: string,
+  category: string,
+  label?: string,
+  value?: number
+) => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', action, {
+      event_category: category,
+      event_label: label,
+      value: value,
+    });
+  }
+};
+
+// Predefined tracking functions
+export const trackPageView = (url: string) => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('config', process.env.NEXT_PUBLIC_GA_ID, {
+      page_path: url,
+    });
+  }
+};
+
+export const trackContactClick = () => {
+  trackEvent('click', 'engagement', 'contact_button');
+};
+
+export const trackProjectClick = (projectName: string) => {
+  trackEvent('click', 'engagement', `project_${projectName}`);
+};
+
+export const trackBlogRead = (postTitle: string) => {
+  trackEvent('read', 'engagement', `blog_${postTitle}`);
+};
+
+export const trackExternalLink = (url: string) => {
+  trackEvent('click', 'outbound', url);
+};
+
+export const trackScrollDepth = (depth: number) => {
+  trackEvent('scroll', 'engagement', `scroll_${depth}%`);
+}; 

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -11,6 +11,7 @@ import theme from "../theme";
 import type { AppProps } from "next/app";
 import { roboto } from "@/lib/fonts";
 import GoogleAnalytics from "@/components/common/GoogleAnalytics";
+import PrivacyModal from "@/components/common/PrivacyModal";
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
@@ -34,6 +35,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <link rel="apple-touch-icon" href="/af_large.png" />
       </Head>
       <GoogleAnalytics />
+      <PrivacyModal />
       <ThemeProvider theme={theme}>
         <VisibilityProvider>
           <PageLayout className={roboto.variable}>


### PR DESCRIPTION
feat: replace cookie banner with elegant privacy modal and footer link

- Create responsive PrivacyModal component (modal on desktop, drawer on mobile)
- Update footer with three-column layout: Privacy left, Copyright center, Icons right
- Use personal language ('I/my') instead of corporate ('we/our')
- Add analytics utility foundation for future event tracking
- Remove intrusive cookie banner in favor of discoverable footer link

Improves UX by making privacy controls non-intrusive while maintaining
compliance and professional appearance. Better suited for personal portfolio.

Addresses #404

closes #404