### PR TITLE
408: [blog] Add inline image support with HTML styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,29 @@ This repository implements a hybrid architecture that leverages both static site
   Provides a simple, readable format for blog content that can be easily edited in any text editor or IDE.
 
 ---
+
+## Blog Inline Images
+
+The blog system supports inline images with styling control:
+
+### Quick Start
+```markdown
+<!-- Standard markdown (full width) -->
+![Description](/blog/image.jpg)
+
+<!-- HTML with custom sizing -->
+<img src="/blog/image.jpg" alt="Description" width="400" />
+```
+
+### Features
+- **Responsive scaling** and click-to-expand modal
+- **Custom sizing** via HTML attributes or CSS  
+- **Support for all formats** (JPG, PNG, SVG, GIF)
+- **Professional styling** with hover effects
+
+### File Organization
+Place blog images in: `web/public/blog/`
+
+For complete styling examples and best practices, use either standard markdown for full-width images or HTML `<img>` tags with `width`, `height`, or `style` attributes for custom sizing.
+
+---

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
+    "rehype-raw": "^7.0.0",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1"
   },

--- a/web/src/components/blog/BlogPost.tsx
+++ b/web/src/components/blog/BlogPost.tsx
@@ -1,11 +1,13 @@
 "use client";
 import React, { useState } from "react";
 import NextLink from "next/link";
-import { Box, Typography, Container, Divider, Button, Link as MuiLink, Paper, Snackbar, Chip } from "@mui/material";
+import { Box, Typography, Container, Divider, Button, Link as MuiLink, Paper, Snackbar, Chip, Modal, IconButton, useTheme, useMediaQuery } from "@mui/material";
 import ShareIcon from '@mui/icons-material/Share';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import CloseIcon from '@mui/icons-material/Close';
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
 import { Post } from "../../types/blog";
 
 interface BlogPostProps {
@@ -14,6 +16,13 @@ interface BlogPostProps {
 
 export default function BlogPost({ post }: BlogPostProps) {
     const [showCopySuccess, setShowCopySuccess] = useState(false);
+    const [imageModal, setImageModal] = useState<{ open: boolean; src: string; alt: string }>({
+        open: false,
+        src: '',
+        alt: ''
+    });
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     const handleShare = async () => {
         try {
@@ -22,6 +31,14 @@ export default function BlogPost({ post }: BlogPostProps) {
         } catch (err) {
             console.error('Failed to copy URL:', err);
         }
+    };
+
+    const handleImageClick = (src: string, alt: string) => {
+        setImageModal({ open: true, src, alt });
+    };
+
+    const closeImageModal = () => {
+        setImageModal({ open: false, src: '', alt: '' });
     };
 
     return (
@@ -99,7 +116,10 @@ export default function BlogPost({ post }: BlogPostProps) {
                 </Box>
                 <Divider sx={{ my: 4 }} />
                 <Box sx={{ "& img": { maxWidth: "100%", height: "auto", borderRadius: 2 }, "& pre": { overflowX: "auto" } }}>
-                    <ReactMarkdown remarkPlugins={[remarkGfm]} components={{
+                    <ReactMarkdown 
+                        remarkPlugins={[remarkGfm]} 
+                        rehypePlugins={[rehypeRaw]}
+                        components={{
                         h2: ({ ...props }) => (
                             <Typography variant="h4" gutterBottom sx={{ mt: 4 }} {...props} />
                         ),
@@ -130,6 +150,57 @@ export default function BlogPost({ post }: BlogPostProps) {
                                 {children}
                             </MuiLink>
                         ),
+                        img: ({ src, alt, style, width, height, ...props }) => {
+                            // Parse custom styling from props
+                            const customStyles: any = {};
+                            let finalMaxWidth = "100%"; // Default
+                            
+                            if (width) {
+                                if (typeof width === 'string' && width.includes('%')) {
+                                    finalMaxWidth = width;
+                                    customStyles.width = width;
+                                } else {
+                                    const pixelWidth = typeof width === 'number' ? `${width}px` : width;
+                                    customStyles.width = pixelWidth;
+                                    finalMaxWidth = pixelWidth;
+                                }
+                            }
+                            
+                            if (height) {
+                                customStyles.height = typeof height === 'number' ? `${height}px` : height;
+                            }
+                            
+                            // Parse inline styles if provided
+                            if (style) {
+                                Object.assign(customStyles, style);
+                            }
+                            
+                            return (
+                                <Box
+                                    component="img"
+                                    src={src}
+                                    alt={alt || "Blog image"}
+                                    onClick={() => handleImageClick(src || '', alt || 'Blog image')}
+                                    sx={{
+                                        maxWidth: finalMaxWidth,
+                                        height: "auto",
+                                        borderRadius: 2,
+                                        cursor: "pointer",
+                                        my: 3,
+                                        display: "block",
+                                        mx: "auto",
+                                        boxShadow: 2,
+                                        transition: "transform 0.3s, box-shadow 0.3s",
+                                        "&:hover": {
+                                            transform: "scale(1.02)",
+                                            boxShadow: 4
+                                        },
+                                        ...customStyles
+                                    }}
+                                    {...props}
+                                />
+                            );
+                        },
                         code: ({ inline, children, ...props }: { inline?: boolean; children?: React.ReactNode; [key: string]: any }) =>
                             // Fallback: treat as inline unless we explicitly detect a block (multiple lines)
                             (inline ?? !String(children).includes('\n')) ? (
@@ -164,6 +235,50 @@ export default function BlogPost({ post }: BlogPostProps) {
                     </ReactMarkdown>
                 </Box>
             </Paper>
+
+            {/* Image Modal */}
+            <Modal open={imageModal.open} onClose={closeImageModal}>
+                <Box
+                    sx={{
+                        position: 'fixed',
+                        top: 0,
+                        left: 0,
+                        width: '100vw',
+                        height: '100vh',
+                        bgcolor: 'rgba(0,0,0,0.9)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        zIndex: 1300,
+                    }}
+                >
+                    <IconButton
+                        onClick={closeImageModal}
+                        sx={{
+                            position: 'absolute',
+                            top: 24,
+                            right: 24,
+                            color: '#fff',
+                            zIndex: 1400,
+                        }}
+                        aria-label="Close image"
+                    >
+                        <CloseIcon fontSize="large" />
+                    </IconButton>
+                    <Box
+                        component="img"
+                        src={imageModal.src}
+                        alt={imageModal.alt}
+                        sx={{
+                            maxWidth: isMobile ? '90vw' : '80vw',
+                            maxHeight: isMobile ? '70vh' : '80vh',
+                            objectFit: 'contain',
+                            borderRadius: 2,
+                        }}
+                    />
+                </Box>
+            </Modal>
+
             <Snackbar
                 open={showCopySuccess}
                 autoHideDuration={2000}

--- a/web/src/data/experience.json
+++ b/web/src/data/experience.json
@@ -337,8 +337,8 @@
     "artifacts": [
       {
         "url": "https://pourtle.com",
-        "title": "Pourtle | Your content where you need it",
-        "description": "Web site created using create-react-app",
+        "title": "Pourtle | Instantly share files, photos, and more",
+        "description": "Share files instantly with secure peer-to-peer connections. No uploads, no storage, just direct file sharing between devices. Fast, private, and easy.",
         "image": "https://pourtle.com/pourtle.png"
       }
     ],
@@ -368,7 +368,7 @@
         "url": "https://www.alexfischman.dev/blog/2025-07-02-how-i-built-my-personal-website/",
         "title": "How I Built alexfischman.dev | Alex Fischman",
         "description": "A technical breakdown of my website intertwined with lessons I've learned along the way",
-        "image": "https://www.alexfischman.dev/af_dark.png"
+        "image": "https://www.alexfischman.devaf_dark.png/"
       }
     ],
     "slug": "alexfischman-dev"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2185,6 +2185,46 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-from-parse5@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz#830a35022fff28c3fea3697a98c2f4cc6b835a2e"
+  integrity sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    devlop "^1.0.0"
+    hastscript "^9.0.0"
+    property-information "^7.0.0"
+    vfile "^6.0.0"
+    vfile-location "^5.0.0"
+    web-namespaces "^2.0.0"
+
+hast-util-parse-selector@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-raw@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-9.1.0.tgz#79b66b26f6f68fb50dfb4716b2cdca90d92adf2e"
+  integrity sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    hast-util-from-parse5 "^8.0.0"
+    hast-util-to-parse5 "^8.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    parse5 "^7.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz#ff31897aae59f62232e21594eac7ef6b63333e98"
@@ -2206,12 +2246,36 @@ hast-util-to-jsx-runtime@^2.0.0:
     unist-util-position "^5.0.0"
     vfile-message "^4.0.0"
 
+hast-util-to-parse5@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz#477cd42d278d4f036bc2ea58586130f6f39ee6ed"
+  integrity sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    devlop "^1.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-whitespace@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
   integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
   dependencies:
     "@types/hast" "^3.0.0"
+
+hastscript@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-9.0.1.tgz#dbc84bef6051d40084342c229c451cd9dc567dff"
+  integrity sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^4.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
 
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
@@ -2224,6 +2288,11 @@ html-url-attributes@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz#83b052cd5e437071b756cd74ae70f708870c2d87"
   integrity sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==
+
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
 htmlparser2@^8.0.1:
   version "8.0.2"
@@ -3412,6 +3481,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-information@^6.0.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.5.0.tgz#6212fbb52ba757e92ef4fb9d657563b933b7ffec"
+  integrity sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==
+
 property-information@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.0.0.tgz#3508a6d6b0b8eb3ca6eb2c6623b164d2ed2ab112"
@@ -3516,6 +3590,15 @@ regexp.prototype.flags@^1.5.3:
     get-proto "^1.0.1"
     gopd "^1.2.0"
     set-function-name "^2.0.2"
+
+rehype-raw@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
+  integrity sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-raw "^9.0.0"
+    vfile "^6.0.0"
 
 remark-gfm@^4.0.1:
   version "4.0.1"
@@ -4155,6 +4238,14 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
+vfile-location@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
+  integrity sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile "^6.0.0"
+
 vfile-message@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.2.tgz#c883c9f677c72c166362fd635f21fc165a7d1181"
@@ -4170,6 +4261,11 @@ vfile@^6.0.0:
   dependencies:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
+
+web-namespaces@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
feat: enhance blog post component with inline image support and modal display

- Add support for inline images in blog posts with responsive styling options.
- Implement image modal for viewing images in full size with close functionality.
- Update README to include documentation on inline image usage and features.
- Add rehype-raw dependency for handling raw HTML in markdown.

Addresses #408

closes #408