### PR TITLE
418: [blog] Link preview og images missing

### DIFF
--- a/web/src/pages/blog/[slug].tsx
+++ b/web/src/pages/blog/[slug].tsx
@@ -16,7 +16,7 @@ export default function BlogPostPage({ post }: BlogPostPageProps) {
       <CustomHead
         title={`${post.title} | Alex Fischman`}
         description={post.description}
-        ogImage={post.ogImage || 'af_dark.png'}
+        ogImage={post.ogImage || '/af_dark.png'}
         ogUrl={`https://www.alexfischman.dev/blog/${post.slug}`}
       />
       <Container sx={{ p: 0 }}>

--- a/web/src/pages/blog/index.tsx
+++ b/web/src/pages/blog/index.tsx
@@ -13,7 +13,7 @@ export default function BlogIndex({ posts }: { posts: Post[] }) {
             <CustomHead
                 title="Blog | Alex Fischman"
                 description="Read the latest blog posts by Alex Fischman on software engineering, AI, technology, weather, and more."
-                ogImage="af_dark.png"
+                ogImage="/af_dark.png"
                 ogUrl="https://www.alexfischman.dev/blog"
             />
             <Box sx={{ minHeight: '100%', display: 'flex', flexDirection: 'column' }}>

--- a/web/src/pages/experience/[slug].tsx
+++ b/web/src/pages/experience/[slug].tsx
@@ -16,7 +16,7 @@ export default function ExperienceSlugPage({ experience }: ExperienceSlugPagePro
       <CustomHead
         title={`${experience.title} | Alex Fischman`}
         description={experience.description}
-        ogImage={experience.ogImage || 'af_dark.png'}
+        ogImage={experience.ogImage || '/af_dark.png'}
         ogUrl={`https://www.alexfischman.dev/experience/${experience.slug}`}
       />
       <Container sx={{ p: 0 }}>

--- a/web/src/pages/experience/index.tsx
+++ b/web/src/pages/experience/index.tsx
@@ -80,7 +80,7 @@ export default function ExperiencePage({
             <CustomHead
                 title="Experience | Alex Fischman – Senior Software Engineer & Founder"
                 description="Explore projects and professional experiences by Alex Fischman."
-                ogImage="af_dark.png"
+                ogImage="/af_dark.png"
                 ogUrl="https://www.alexfischman.dev/experience"
             />
             <Box sx={{ width: '100%', p: 0 }}>


### PR DESCRIPTION
fix: update ogImage paths to ensure correct loading in blog and experience pages

- Change ogImage paths from relative to absolute by adding a leading slash in blog and experience pages.
- This adjustment ensures consistent image loading across different environments.

closes #418